### PR TITLE
moved tmux style definitions to newer syntax

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -26,16 +26,11 @@ set-option -g mouse on
 set-window-option -g mode-keys vi
 
 # configure the window selector
-set-window-option -g window-status-current-attr bold
-set-window-option -g window-status-current-bg black
-set-window-option -g window-status-current-fg yellow
-set-window-option -g window-status-current-attr underscore
+set-window-option -g window-status-current-style bg=black,fg=yellow,underscore
 set-window-option -g window-status-separator " | "
 
 # configure the status bar
-set-option -g status-fg green
-set-option -g status-bg black
-set-option -g status-attr underscore
+set-option -g status-style fg=green,bg=black,underscore
 set-option -g status-position top
 set-option -g status-left-length 100
 set-option -g status-left "[#{session_name}] #{host}:#{pane_current_path} |"
@@ -43,7 +38,5 @@ set-option -g status-right-length 100
 set-option -g status-right "| #(uptime|cut -d "," -f 3-) | %H:%M %F"
 
 # configure copy mode
-set-window-option -g mode-attr none
-set-window-option -g mode-bg black
-set-window-option -g mode-fg red
+set-window-option -g mode-style bg=black,fg=red,bold
 


### PR DESCRIPTION
The new syntax was introduced in tmux 1.9, so this should work on all modern Linux installations.